### PR TITLE
Add ChatGPT integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## OpenAI API setup
+
+This app uses the OpenAI ChatGPT API. Edit `lib/openai_config.dart` and replace
+`REPLACE_WITH_YOUR_OPENAI_API_KEY` with your personal API key. Keys can be
+created at <https://platform.openai.com/account/api-keys>.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'pages/history_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -30,7 +31,7 @@ class MyApp extends StatelessWidget {
         // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      home: const HistoryPage(),
     );
   }
 }

--- a/lib/models/chat_models.dart
+++ b/lib/models/chat_models.dart
@@ -1,0 +1,40 @@
+class Message {
+  final String role;
+  final String content;
+
+  Message({required this.role, required this.content});
+
+  Map<String, dynamic> toJson() => {'role': role, 'content': content};
+
+  factory Message.fromJson(Map<String, dynamic> json) {
+    return Message(role: json['role'], content: json['content']);
+  }
+}
+
+class Conversation {
+  final String id;
+  List<Message> messages;
+
+  Conversation({required this.id, required this.messages});
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'messages': messages.map((m) => m.toJson()).toList(),
+      };
+
+  factory Conversation.fromJson(Map<String, dynamic> json) {
+    return Conversation(
+      id: json['id'],
+      messages: (json['messages'] as List<dynamic>)
+          .map((e) => Message.fromJson(e))
+          .toList(),
+    );
+  }
+
+  String get title {
+    for (final m in messages) {
+      if (m.role == 'user') return m.content;
+    }
+    return 'Conversation';
+  }
+}

--- a/lib/openai_config.dart
+++ b/lib/openai_config.dart
@@ -1,0 +1,1 @@
+const openAIApiKey = 'REPLACE_WITH_YOUR_OPENAI_API_KEY';

--- a/lib/pages/chat_page.dart
+++ b/lib/pages/chat_page.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import '../models/chat_models.dart';
+import '../services/chat_service.dart';
+import '../services/conversation_storage.dart';
+
+class ChatPage extends StatefulWidget {
+  final Conversation conversation;
+  final ConversationStorage storage;
+  const ChatPage({super.key, required this.conversation, required this.storage});
+
+  @override
+  State<ChatPage> createState() => _ChatPageState();
+}
+
+class _ChatPageState extends State<ChatPage> {
+  final _controller = TextEditingController();
+  final _service = ChatService();
+  bool _sending = false;
+
+  Future<void> _send() async {
+    final text = _controller.text.trim();
+    if (text.isEmpty) return;
+    setState(() {
+      widget.conversation.messages.add(Message(role: 'user', content: text));
+      _sending = true;
+    });
+    _controller.clear();
+    try {
+      final reply = await _service.send(widget.conversation.messages, text);
+      setState(() {
+        widget.conversation.messages.add(reply);
+      });
+      await widget.storage.save([widget.conversation]);
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Error: $e')),
+      );
+    }
+    setState(() {
+      _sending = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.conversation.title)),
+      body: Column(
+        children: [
+          Expanded(
+            child: ListView.builder(
+              itemCount: widget.conversation.messages.length,
+              itemBuilder: (context, index) {
+                final msg = widget.conversation.messages[index];
+                return ListTile(
+                  title: Text(msg.content),
+                  subtitle: Text(msg.role),
+                );
+              },
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _controller,
+                    decoration: const InputDecoration(
+                      hintText: 'Type your message',
+                    ),
+                    onSubmitted: (_) => _send(),
+                  ),
+                ),
+                IconButton(
+                  icon: _sending
+                      ? const SizedBox(
+                          width: 24,
+                          height: 24,
+                          child: CircularProgressIndicator(),
+                        )
+                      : const Icon(Icons.send),
+                  onPressed: _sending ? null : _send,
+                ),
+              ],
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/history_page.dart
+++ b/lib/pages/history_page.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import '../models/chat_models.dart';
+import '../services/conversation_storage.dart';
+import 'chat_page.dart';
+
+class HistoryPage extends StatefulWidget {
+  const HistoryPage({super.key});
+
+  @override
+  State<HistoryPage> createState() => _HistoryPageState();
+}
+
+class _HistoryPageState extends State<HistoryPage> {
+  final _storage = ConversationStorage();
+  List<Conversation> _conversations = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final data = await _storage.load();
+    setState(() => _conversations = data);
+  }
+
+  Future<void> _openConversation(Conversation c) async {
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => ChatPage(conversation: c, storage: _storage),
+      ),
+    );
+    await _storage.save(_conversations);
+    _load();
+  }
+
+  Future<void> _newConversation() async {
+    final conv = Conversation(id: DateTime.now().toIso8601String(), messages: []);
+    _conversations.add(conv);
+    await _openConversation(conv);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Conversations')),
+      body: ListView.builder(
+        itemCount: _conversations.length,
+        itemBuilder: (context, index) {
+          final conv = _conversations[index];
+          return ListTile(
+            title: Text(conv.title),
+            onTap: () => _openConversation(conv),
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _newConversation,
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import '../models/chat_models.dart';
+import '../openai_config.dart';
+
+class ChatService {
+  Future<Message> send(List<Message> history, String prompt) async {
+    final uri = Uri.parse('https://api.openai.com/v1/chat/completions');
+    final body = jsonEncode({
+      'model': 'gpt-3.5-turbo',
+      'messages': [
+        ...history.map((m) => m.toJson()),
+        {'role': 'user', 'content': prompt},
+      ],
+    });
+
+    final response = await http.post(
+      uri,
+      headers: {
+        'Authorization': 'Bearer $openAIApiKey',
+        'Content-Type': 'application/json',
+      },
+      body: body,
+    );
+
+    if (response.statusCode == 200) {
+      final data = jsonDecode(response.body);
+      final content = data['choices'][0]['message']['content'];
+      return Message(role: 'assistant', content: content.trim());
+    } else {
+      throw Exception('OpenAI request failed: ${response.body}');
+    }
+  }
+}

--- a/lib/services/conversation_storage.dart
+++ b/lib/services/conversation_storage.dart
@@ -1,0 +1,21 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../models/chat_models.dart';
+
+class ConversationStorage {
+  static const _key = 'conversations';
+
+  Future<List<Conversation>> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final text = prefs.getString(_key);
+    if (text == null) return [];
+    final List<dynamic> data = jsonDecode(text);
+    return data.map((e) => Conversation.fromJson(e)).toList();
+  }
+
+  Future<void> save(List<Conversation> conversations) async {
+    final prefs = await SharedPreferences.getInstance();
+    final text = jsonEncode(conversations.map((e) => e.toJson()).toList());
+    await prefs.setString(_key, text);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  http: ^1.1.0
+  shared_preferences: ^2.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add models for messages and conversations
- add a chat page that connects to OpenAI
- store conversation history with `shared_preferences`
- show conversation list in new history page
- document how to configure the API key

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e6742ad5883259746204c38ff7291